### PR TITLE
Initial 1.20.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,23 @@
-/build/
-/run/
-/.idea/
-/.gradle/
-/api/.gradle/
-/api/build/
-/build-logic/.gradle/
-/build-logic/build/
-/fabric/.gradle/
-/fabric/build/
-/fabric/run/
-/forge/.gradle/
-/forge/build/
-/forge/run/
-*.iml
+/*.iml
+### Gradle template
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
-/*.iml
+/build/
+/run/
+/.idea/
+/.gradle/
+/api/.gradle/
+/api/build/
+/build-logic/.gradle/
+/build-logic/build/
+/fabric/.gradle/
+/fabric/build/
+/fabric/run/
+/forge/.gradle/
+/forge/build/
+/forge/run/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /*.iml
+.idea
+**/run/
 ### Gradle template
 .gradle
 **/build/

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -17,6 +17,9 @@ repositories {
 
 dependencies {
     modImplementation("net.fabricmc:fabric-loader:${rootProject.property("fabric-loader")}")
+    // https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
+    implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
+
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/UIManager.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/UIManager.java
@@ -5,7 +5,7 @@ import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.tasks.Task;
 import net.minecraft.server.level.ServerPlayer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/Button.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/Button.java
@@ -3,7 +3,7 @@ package ca.landonjw.gooeylibs2.api.button;
 import ca.landonjw.gooeylibs2.api.data.Subject;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public interface Button extends Subject<Button> {
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/ButtonAction.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/ButtonAction.java
@@ -4,7 +4,7 @@ import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.template.Template;
 import net.minecraft.server.level.ServerPlayer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/ButtonBase.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/ButtonBase.java
@@ -3,7 +3,7 @@ package ca.landonjw.gooeylibs2.api.button;
 import ca.landonjw.gooeylibs2.api.data.UpdateEmitter;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import static java.util.Objects.requireNonNull;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/FlagType.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/FlagType.java
@@ -6,26 +6,15 @@ public enum FlagType
      * ENCHANTS only hides tool enchants, as book ones are classified as stored enchantments.
      * EXTRAS hides multiple things, according to the minecraft wiki (https://minecraft.fandom.com/wiki/Tutorials/Command_NBT_tags)
      */
-    Reforged(0),
-    Generations(0),
-    Enchantments(1),
-    Attribute_Modifiers(2),
-    Unbreakable(4),
-    Can_Destroy(8),
-    Can_Place_On(16),
-    Extras(32),
-    Dyed_Leather(64),
-    All(127);
-
-    private final int value;
-
-    FlagType(int value)
-    {
-        this.value = value;
-    }
-
-    public int getValue()
-    {
-        return this.value;
-    }
+    Hide_Tooltip,
+    Enchantments,
+    Attribute_Modifiers,
+    Unbreakable,
+    Can_Break,
+    Can_Place_On,
+    Stored_Enchantments,
+    Dyed_Color,
+    Trim,
+    Hide_Additional_Tooltip,
+    All;
 }

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/FlagType.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/FlagType.java
@@ -2,10 +2,6 @@ package ca.landonjw.gooeylibs2.api.button;
 
 public enum FlagType
 {
-    /**
-     * ENCHANTS only hides tool enchants, as book ones are classified as stored enchantments.
-     * EXTRAS hides multiple things, according to the minecraft wiki (https://minecraft.fandom.com/wiki/Tutorials/Command_NBT_tags)
-     */
     Hide_Tooltip,
     Enchantments,
     Attribute_Modifiers,

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/GooeyButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/GooeyButton.java
@@ -15,8 +15,8 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.component.ItemLore;
 import net.minecraft.world.item.component.Unbreakable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/GooeyButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/GooeyButton.java
@@ -1,20 +1,23 @@
 package ca.landonjw.gooeylibs2.api.button;
 
 import com.google.common.collect.Lists;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.StringTag;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
+import net.minecraft.util.Unit;
+import net.minecraft.world.item.AdventureModePredicate;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.armortrim.ArmorTrim;
+import net.minecraft.world.item.component.DyedItemColor;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
+import net.minecraft.world.item.component.ItemLore;
+import net.minecraft.world.item.component.Unbreakable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -122,36 +125,89 @@ public class GooeyButton extends ButtonBase {
                 MutableComponent result = Component.empty()
                         .setStyle(Style.EMPTY.withItalic(false))
                         .append(this.title);
-                display.setHoverName(result);
+                display.applyComponents(DataComponentPatch.builder()
+                        .set(DataComponents.CUSTOM_NAME, result)
+                        .build());
             }
 
             if (!lore.isEmpty()) {
-                ListTag nbtLore = new ListTag();
-                for (Component line : lore) {
-                    MutableComponent result = Component.empty()
-                            .setStyle(Style.EMPTY.withItalic(false))
-                            .append(line);
-                    nbtLore.add(StringTag.valueOf(Component.Serializer.toJson(result)));
-                }
-                display.getOrCreateTagElement("display").put("Lore", nbtLore);
+                display.applyComponents(DataComponentPatch.builder()
+                        .set(DataComponents.LORE, new ItemLore(Collections.emptyList(), lore.stream().map((it) ->
+                                Component.empty()
+                                .setStyle(Style.EMPTY.withItalic(false))
+                                .append(it)).collect(Collectors.toList())))
+                        .build());
             }
 
-            if (!this.hideFlags.isEmpty() && display.hasTag())
-            {
-                if (this.hideFlags.contains(FlagType.Reforged) || this.hideFlags.contains(FlagType.All))
-                {
-                    display.getOrCreateTag().putString("tooltip", "");
+            if (!this.hideFlags.isEmpty()) {
+                if (this.hideFlags.contains(FlagType.Hide_Tooltip) || this.hideFlags.contains(FlagType.All)) {
+                    display.applyComponents(DataComponentPatch.builder()
+                            .set(DataComponents.HIDE_TOOLTIP, Unit.INSTANCE)
+                            .build());
                 }
-                if (this.hideFlags.contains(FlagType.Generations) || this.hideFlags.contains(FlagType.All))
-                {
-                    display.getOrCreateTag().putBoolean("HideTooltip", true);
+                if (this.hideFlags.contains(FlagType.Enchantments) || this.hideFlags.contains(FlagType.All)) {
+                    display.applyComponents(DataComponentPatch.builder()
+                            .set(DataComponents.ENCHANTMENTS, display.getEnchantments().withTooltip(false))
+                            .build());
                 }
-                int value = 0;
-                for (FlagType flag : this.hideFlags)
-                {
-                    value += flag.getValue();
+                if (this.hideFlags.contains(FlagType.Attribute_Modifiers) || this.hideFlags.contains(FlagType.All)) {
+                    display.applyComponents(DataComponentPatch.builder()
+                            .set(DataComponents.ATTRIBUTE_MODIFIERS, display.getOrDefault(
+                                            DataComponents.ATTRIBUTE_MODIFIERS,
+                                            ItemAttributeModifiers.EMPTY
+                                    ).withTooltip(false))
+                            .build());
                 }
-                display.getOrCreateTag().putInt("HideFlags", value);
+                if (this.hideFlags.contains(FlagType.Unbreakable) || this.hideFlags.contains(FlagType.All)) {
+                    Unbreakable unbreakable = display.get(DataComponents.UNBREAKABLE);
+                    if (unbreakable != null) {
+                        display.applyComponents(DataComponentPatch.builder()
+                                .set(DataComponents.UNBREAKABLE, unbreakable.withTooltip(false))
+                                .build());
+                    }
+                }
+                if (this.hideFlags.contains(FlagType.Can_Break) || this.hideFlags.contains(FlagType.All)) {
+                    AdventureModePredicate canBreak = display.get(DataComponents.CAN_BREAK);
+                    if (canBreak != null) {
+                        display.applyComponents(DataComponentPatch.builder()
+                                .set(DataComponents.CAN_BREAK, canBreak.withTooltip(false))
+                                .build());
+                    }
+                }
+                if (this.hideFlags.contains(FlagType.Can_Place_On) || this.hideFlags.contains(FlagType.All)) {
+                    AdventureModePredicate canPlaceOn = display.get(DataComponents.CAN_PLACE_ON);
+                    if (canPlaceOn != null) {
+                        display.applyComponents(DataComponentPatch.builder()
+                                .set(DataComponents.CAN_PLACE_ON, canPlaceOn.withTooltip(false))
+                                .build());
+                    }
+                }
+                if (this.hideFlags.contains(FlagType.Stored_Enchantments) || this.hideFlags.contains(FlagType.All)) {
+                    display.applyComponents(DataComponentPatch.builder()
+                            .set(DataComponents.STORED_ENCHANTMENTS, display.getEnchantments().withTooltip(false))
+                            .build());
+                }
+                if (this.hideFlags.contains(FlagType.Dyed_Color) || this.hideFlags.contains(FlagType.All)) {
+                    DyedItemColor dyedColor = display.get(DataComponents.DYED_COLOR);
+                    if (dyedColor != null) {
+                        display.applyComponents(DataComponentPatch.builder()
+                                .set(DataComponents.DYED_COLOR, dyedColor.withTooltip(false))
+                                .build());
+                    }
+                }
+                if (this.hideFlags.contains(FlagType.Trim) || this.hideFlags.contains(FlagType.All)) {
+                    ArmorTrim trim = display.get(DataComponents.TRIM);
+                    if (trim != null) {
+                        display.applyComponents(DataComponentPatch.builder()
+                                .set(DataComponents.TRIM, trim.withTooltip(false))
+                                .build());
+                    }
+                }
+                if (this.hideFlags.contains(FlagType.Hide_Additional_Tooltip) || this.hideFlags.contains(FlagType.All)) {
+                    display.applyComponents(DataComponentPatch.builder()
+                            .set(DataComponents.HIDE_ADDITIONAL_TOOLTIP, Unit.INSTANCE)
+                            .build());
+                }
             }
             return display;
         }

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/InventoryListenerButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/InventoryListenerButton.java
@@ -2,8 +2,8 @@ package ca.landonjw.gooeylibs2.api.button;
 
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.function.Consumer;
 
 public class InventoryListenerButton extends ButtonBase {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/PlaceholderButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/PlaceholderButton.java
@@ -2,7 +2,7 @@ package ca.landonjw.gooeylibs2.api.button;
 
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.function.Consumer;
 
 public class PlaceholderButton implements Button {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/RateLimitedButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/RateLimitedButton.java
@@ -1,6 +1,6 @@
 package ca.landonjw.gooeylibs2.api.button;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedList;

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/linked/LinkedPageButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/linked/LinkedPageButton.java
@@ -8,8 +8,8 @@ import ca.landonjw.gooeylibs2.api.page.Page;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.function.Consumer;
 
 public class LinkedPageButton extends GooeyButton {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/moveable/MovableButton.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/moveable/MovableButton.java
@@ -5,8 +5,8 @@ import ca.landonjw.gooeylibs2.api.button.GooeyButton;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Collection;
 import java.util.function.Consumer;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/button/moveable/MovableButtonAction.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/button/moveable/MovableButtonAction.java
@@ -7,7 +7,7 @@ import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.template.Template;
 import net.minecraft.server.level.ServerPlayer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public class MovableButtonAction extends ButtonAction {
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -29,7 +29,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 
 public class GooeyContainer extends AbstractContainerMenu {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/data/EventEmitter.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/data/EventEmitter.java
@@ -2,7 +2,7 @@ package ca.landonjw.gooeylibs2.api.data;
 
 import com.google.common.collect.Maps;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Map;
 import java.util.function.Consumer;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/data/Subject.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/data/Subject.java
@@ -1,6 +1,6 @@
 package ca.landonjw.gooeylibs2.api.data;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.function.Consumer;
 
 public interface Subject<T> {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/data/UpdateEmitter.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/data/UpdateEmitter.java
@@ -1,6 +1,6 @@
 package ca.landonjw.gooeylibs2.api.data;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.function.Consumer;
 
 public abstract class UpdateEmitter<T> implements Subject<T> {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/helpers/InventoryHelper.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/helpers/InventoryHelper.java
@@ -5,8 +5,8 @@ import ca.landonjw.gooeylibs2.api.tasks.Task;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Utility functions that are used to conveniently modify player's inventories when using GooeyLibs pages.

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/helpers/PaginationHelper.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/helpers/PaginationHelper.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.page.LinkedPage;
 import ca.landonjw.gooeylibs2.api.page.PageAction;
 import ca.landonjw.gooeylibs2.api.template.Template;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/page/GooeyPage.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/page/GooeyPage.java
@@ -4,8 +4,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.types.InventoryTemplate;
 import net.minecraft.network.chat.Component;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.function.Consumer;
 
 public class GooeyPage extends PageBase {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/page/LinkedPage.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/page/LinkedPage.java
@@ -5,8 +5,8 @@ import ca.landonjw.gooeylibs2.api.template.types.InventoryTemplate;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/page/Page.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/page/Page.java
@@ -5,7 +5,7 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.types.InventoryTemplate;
 import net.minecraft.network.chat.Component;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Optional;
 
 public interface Page extends Subject<Page> {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/page/PageAction.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/page/PageAction.java
@@ -2,7 +2,7 @@ package ca.landonjw.gooeylibs2.api.page;
 
 import net.minecraft.server.level.ServerPlayer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public class PageAction {
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/page/PageBase.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/page/PageBase.java
@@ -5,8 +5,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.types.InventoryTemplate;
 import net.minecraft.network.chat.Component;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.Consumer;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/tasks/Task.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/tasks/Task.java
@@ -1,8 +1,8 @@
 package ca.landonjw.gooeylibs2.api.tasks;
 
 import ca.landonjw.gooeylibs2.bootstrap.GooeyBootstrapper;
+import jakarta.annotation.Nonnull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
 public interface Task {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/Template.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/Template.java
@@ -4,7 +4,7 @@ import ca.landonjw.gooeylibs2.api.data.UpdateEmitter;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.List;
 
 public abstract class Template extends UpdateEmitter<Template> {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/TemplateType.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/TemplateType.java
@@ -4,7 +4,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.function.Function;
 
 public enum TemplateType {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/slot/TemplateSlot.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/slot/TemplateSlot.java
@@ -6,7 +6,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.util.Optional;
 
 public final class TemplateSlot extends Slot {

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/slot/TemplateSlotDelegate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/slot/TemplateSlotDelegate.java
@@ -5,7 +5,7 @@ import ca.landonjw.gooeylibs2.api.data.EventEmitter;
 import ca.landonjw.gooeylibs2.api.data.Subject;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Optional;
 import java.util.function.Consumer;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/BrewingStandTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/BrewingStandTemplate.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/ChestTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/ChestTemplate.java
@@ -7,8 +7,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/CraftingTableTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/CraftingTableTemplate.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/DispenserTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/DispenserTemplate.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/FurnaceTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/FurnaceTemplate.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 public class FurnaceTemplate extends Template {
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/HopperTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/HopperTemplate.java
@@ -6,8 +6,8 @@ import ca.landonjw.gooeylibs2.api.template.Template;
 import ca.landonjw.gooeylibs2.api.template.TemplateType;
 import ca.landonjw.gooeylibs2.api.template.slot.TemplateSlotDelegate;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/InventoryTemplate.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/template/types/InventoryTemplate.java
@@ -9,8 +9,8 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 

--- a/build-logic/src/main/kotlin/gooeylibs.api.gradle.kts
+++ b/build-logic/src/main/kotlin/gooeylibs.api.gradle.kts
@@ -11,8 +11,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 architectury {
@@ -36,11 +36,11 @@ dependencies {
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"
-        options.release.set(17)
+        options.release.set(21)
     }
 
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
+        kotlinOptions.jvmTarget = "21"
     }
 
     withType<Jar> {

--- a/fabric/src/generated/resources/gooeylibs.accesswidener
+++ b/fabric/src/generated/resources/gooeylibs.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible    field    net/minecraft/server/level/ServerPlayer    containerCounter    I

--- a/fabric/src/main/java/ca/landonjw/gooeylibs2/fabric/GooeyLibs.java
+++ b/fabric/src/main/java/ca/landonjw/gooeylibs2/fabric/GooeyLibs.java
@@ -4,7 +4,6 @@ import ca.landonjw.gooeylibs2.api.UIManager;
 import ca.landonjw.gooeylibs2.api.button.Button;
 import ca.landonjw.gooeylibs2.api.button.GooeyButton;
 import ca.landonjw.gooeylibs2.api.page.GooeyPage;
-import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.template.types.ChestTemplate;
 import ca.landonjw.gooeylibs2.api.template.types.InventoryTemplate;
 import net.fabricmc.api.ModInitializer;

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -23,6 +23,6 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "minecraft": ">=1.18.2",
-    "java": ">=17"
+    "java": ">=21"
   }
 }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[40,)"
+loaderVersion="[50,)"
 license="All rights reserved"
 
 [[mods]]
@@ -14,13 +14,13 @@ Server-side library that allows for easy user interface development.
 [[dependencies.gooeylibs2]]
    modId="forge"
    mandatory=true
-   versionRange="[47,)"
+   versionRange="[50,)"
    ordering="NONE"
    side="SERVER"
 
 [[dependencies.gooeylibs2]]
    modId="minecraft"
    mandatory=true
-   versionRange="[1.20.1]"
+   versionRange="[1.20.6]"
    ordering="NONE"
    side="SERVER"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ name=GooeyLibs
 modVersion=3.0.0
 snapshot=true
 
-minecraft=1.20.1
-forge=47.0.3
-fabric-loader=0.14.21
-fabric-api=0.83.1
+minecraft=1.20.6
+forge=50.0.5
+fabric-loader=0.15.10
+fabric-api=0.97.8

--- a/gradle/libs.versions.yml
+++ b/gradle/libs.versions.yml
@@ -2,12 +2,12 @@ versions:
   kotlin: 1.7.10
 
   # Fabric / Forge / Loom / Architectury
-  loom: 0.12.0-SNAPSHOT
-  fabric-loader: 0.14.9
-  fabric-api: 0.59.0+1.18.2
+  loom: 1.6-SNAPSHOT
+  fabric-loader: 0.15.9
+  fabric-api: 0.97.8+1.20.6
   architectury-plugin: 3.4-SNAPSHOT
-  forge: 1.18.2-40.1.0
-  architectury: 6.2.43
+  forge: 1.20.6-50.0.4
+  architectury: 12.0.27
 
   # Misc
   shadow: 7.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This makes version and code changes to support Minecraft 1.20.6

The major changes were in the ItemStack Components. I have opted to rename a few FlagTypes to match their respective DataComponent, as well as adding and separating a few others in line with Minecraft changes. There are likely better ways to handle the DataComponent application than just many IF statements, but it works great as an initial change.

I have cherry-picked several commits from #3 as it was well-timed with this PR.