### PR TITLE
Prevent opening twice

### DIFF
--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -173,6 +173,7 @@ public class GooeyContainer extends AbstractContainerMenu {
     }
 
     public void open() {
+        if (player.containerMenu == this) return;
         player.doCloseContainer();
         player.containerMenu = this;
         player.containerCounter = player.containerMenu.containerId;


### PR DESCRIPTION
This fixes bad desyncs that happen if you accidentally call open() twice.