### PR TITLE
Movable button (and other misc) fixes

### DIFF
--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -25,7 +25,6 @@ import ca.landonjw.gooeylibs2.api.button.ButtonAction;
 import ca.landonjw.gooeylibs2.api.button.ButtonClick;
 import ca.landonjw.gooeylibs2.api.button.GooeyButton;
 import ca.landonjw.gooeylibs2.api.button.moveable.Movable;
-import ca.landonjw.gooeylibs2.api.button.moveable.MovableButton;
 import ca.landonjw.gooeylibs2.api.button.moveable.MovableButtonAction;
 import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.page.PageAction;
@@ -407,9 +406,11 @@ public class GooeyContainer extends AbstractContainerMenu {
             return;
         }
 
+        Button original = null;
         // Handle collision
         if (isSlotOccupied(slot)) {
             setPlayersCursor(cursorButton.getDisplay());
+            original = getButton(slot);
 
             /*
              * When a quick move is performed, it will apply slot clicks to all identical items, causing
@@ -437,7 +438,7 @@ public class GooeyContainer extends AbstractContainerMenu {
             }
 
             setPlayersCursor(cursorButton.getDisplay());
-            updateSlotStack(targetTemplateSlot, ItemStack.EMPTY, template instanceof InventoryTemplate);
+            updateSlotStack(targetTemplateSlot, original == null ? ItemStack.EMPTY : original.getDisplay(), template instanceof InventoryTemplate);
             if (clickType == ClickType.QUICK_CRAFT) {
                 this.updateAllContainerContents();
             }

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -377,7 +377,7 @@ public class GooeyContainer extends AbstractContainerMenu {
         }
 
         ButtonClick click = getButtonClickType(clickType, dragType);
-        MovableButtonAction action = new MovableButtonAction(player, click, clickedButton, template, page, slot);
+        MovableButtonAction action = new MovableButtonAction(player, click, clickedButton, page.getTemplate(), page, slot);
         clickedButton.onClick(action);
         ((Movable) clickedButton).onPickup(action);
 
@@ -427,7 +427,7 @@ public class GooeyContainer extends AbstractContainerMenu {
             }
         }
         ButtonClick click = getButtonClickType(clickType, dragType);
-        MovableButtonAction action = new MovableButtonAction(player, click, cursorButton, template, page, slot);
+        MovableButtonAction action = new MovableButtonAction(player, click, cursorButton, page.getTemplate(), page, slot);
         cursorButton.onClick(action);
         ((Movable) cursorButton).onDrop(action);
 

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -468,7 +468,7 @@ public class GooeyContainer extends AbstractContainerMenu {
     }
 
     private void updateAllContainerContents() {
-        this.refresh(this.player, this.player.containerMenu, this.getItems());
+        this.refresh(this.player, this.player.containerMenu, NonNullList.of(ItemStack.EMPTY, this.getItems().subList(0, page.getTemplate().getSize()).toArray(ItemStack[]::new)));
 
         /*
          * Detects change in the player's inventory and updates them. This is to prevent desyncs if a player

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -377,7 +377,7 @@ public class GooeyContainer extends AbstractContainerMenu {
         }
 
         ButtonClick click = getButtonClickType(clickType, dragType);
-        MovableButtonAction action = new MovableButtonAction(player, click, clickedButton, template, page, targetTemplateSlot);
+        MovableButtonAction action = new MovableButtonAction(player, click, clickedButton, template, page, slot);
         clickedButton.onClick(action);
         ((Movable) clickedButton).onPickup(action);
 
@@ -417,38 +417,38 @@ public class GooeyContainer extends AbstractContainerMenu {
              */
             if (clickType == ClickType.QUICK_MOVE || clickType == ClickType.CLONE || clickType == ClickType.THROW) {
                 this.resetQuickCraft();
+                return;
             }
             else if (clickType == ClickType.QUICK_CRAFT) {
                 updateSlotStack(getTemplateIndex(slot), getItemAtSlot(slot), isSlotInPlayerInventory(slot));
+                return;
+            }
+        }
+        ButtonClick click = getButtonClickType(clickType, dragType);
+        MovableButtonAction action = new MovableButtonAction(player, click, cursorButton, template, page, slot);
+        cursorButton.onClick(action);
+        ((Movable) cursorButton).onDrop(action);
+
+        if (action.isCancelled()) {
+            // Clone needs to return empty ItemStack or it desyncs.
+            if (clickType == ClickType.CLONE) {
+                return;
+            }
+
+            setPlayersCursor(cursorButton.getDisplay());
+            updateSlotStack(targetTemplateSlot, ItemStack.EMPTY, template instanceof InventoryTemplate);
+            if (clickType == ClickType.QUICK_CRAFT) {
+                this.updateAllContainerContents();
             }
         }
         else {
-            ButtonClick click = getButtonClickType(clickType, dragType);
-            MovableButtonAction action = new MovableButtonAction(player, click, cursorButton, template, page, targetTemplateSlot);
-            cursorButton.onClick(action);
-            ((Movable) cursorButton).onDrop(action);
+            setButton(slot, cursorButton);
+            cursorButton = null;
+            setPlayersCursor(ItemStack.EMPTY);
 
-            if (action.isCancelled()) {
-                // Clone needs to return empty ItemStack or it desyncs.
-                if (clickType == ClickType.CLONE) {
-                    return;
-                }
-
-                setPlayersCursor(cursorButton.getDisplay());
-                updateSlotStack(targetTemplateSlot, ItemStack.EMPTY, template instanceof InventoryTemplate);
-                if (clickType == ClickType.QUICK_CRAFT) {
-                    this.updateAllContainerContents();
-                }
-            }
-            else {
-                setButton(slot, cursorButton);
-                cursorButton = null;
-                setPlayersCursor(ItemStack.EMPTY);
-
-                if (clickType == ClickType.QUICK_CRAFT) {
-                    this.updateAllContainerContents();
-                    this.setPlayersCursor(ItemStack.EMPTY);
-                }
+            if (clickType == ClickType.QUICK_CRAFT) {
+                this.updateAllContainerContents();
+                this.setPlayersCursor(ItemStack.EMPTY);
             }
         }
     }

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -437,7 +437,7 @@ public class GooeyContainer extends AbstractContainerMenu {
                 return;
             }
 
-            setPlayersCursor(cursorButton.getDisplay());
+            setPlayersCursor(cursorButton == null ? ItemStack.EMPTY : cursorButton.getDisplay());
             updateSlotStack(targetTemplateSlot, original == null ? ItemStack.EMPTY : original.getDisplay(), template instanceof InventoryTemplate);
             if (clickType == ClickType.QUICK_CRAFT) {
                 this.updateAllContainerContents();

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -25,6 +25,7 @@ import ca.landonjw.gooeylibs2.api.button.ButtonAction;
 import ca.landonjw.gooeylibs2.api.button.ButtonClick;
 import ca.landonjw.gooeylibs2.api.button.GooeyButton;
 import ca.landonjw.gooeylibs2.api.button.moveable.Movable;
+import ca.landonjw.gooeylibs2.api.button.moveable.MovableButton;
 import ca.landonjw.gooeylibs2.api.button.moveable.MovableButtonAction;
 import ca.landonjw.gooeylibs2.api.page.Page;
 import ca.landonjw.gooeylibs2.api.page.PageAction;
@@ -443,8 +444,7 @@ public class GooeyContainer extends AbstractContainerMenu {
         }
         else {
             setButton(slot, cursorButton);
-            cursorButton = null;
-            setPlayersCursor(ItemStack.EMPTY);
+            setCarriedButton(null);
 
             if (clickType == ClickType.QUICK_CRAFT) {
                 this.updateAllContainerContents();
@@ -542,4 +542,8 @@ public class GooeyContainer extends AbstractContainerMenu {
         }
     }
 
+    public void setCarriedButton(MovableButton button) {
+        cursorButton = button;
+        setPlayersCursor(button == null ? ItemStack.EMPTY : button.getDisplay());
+    }
 }

--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/container/GooeyContainer.java
@@ -542,7 +542,7 @@ public class GooeyContainer extends AbstractContainerMenu {
         }
     }
 
-    public void setCarriedButton(MovableButton button) {
+    public void setCarriedButton(Button button) {
         cursorButton = button;
         setPlayersCursor(button == null ? ItemStack.EMPTY : button.getDisplay());
     }


### PR DESCRIPTION
- Make the drop callback fire when dropped onto an occupied slot. This causes it to delete the button it is dropped on by default, but that is easily changeable with the callback and cancelling it. The other default option is to not replace the slot, however that is not intuitive with the way MovableButtons work already.
- Fix wrong slot index bug caused by passing `targetTemplateSlot` instead of `slot` to MoveableButtonAction constructor, which caused things like `isSlotInInventory` to return incorrect results.


The git diff looks a lot larger than it actually is because of the indentation changing, but its just adding a couple returns and unwrapping an `else` block.