### PR TITLE
Fix ConcurrentModificationException in TaskManager tick method

### DIFF
--- a/api/src/main/java/ca/landonjw/gooeylibs2/api/tasks/TaskManager.java
+++ b/api/src/main/java/ca/landonjw/gooeylibs2/api/tasks/TaskManager.java
@@ -19,21 +19,25 @@
 
 package ca.landonjw.gooeylibs2.api.tasks;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class TaskManager {
 
     private static TaskManager INSTANCE;
-    private List<Task> tasks = new ArrayList<>();
+    private List<Task> tasks = new CopyOnWriteArrayList<>();
 
     void register(Task task) {
+        if (task == null) return;
         this.tasks.add(task);
     }
 
     public void tick() {
-        this.tasks.forEach(Task::tick);
-        this.tasks = this.tasks.stream().filter(task -> !task.isExpired()).collect(Collectors.toList());
+        this.tasks.removeIf(task -> {
+            if (task == null) return true;
+            task.tick();
+            return task.isExpired();
+        });
     }
 
     public static TaskManager getInstance() {


### PR DESCRIPTION
Fixes a `ConcurrentModificationException` by iterating over a copy of the task list in `TaskManager.tick()` to prevent concurrent modifications during the loop.

<details>
<summary>Crash Log</summary>
---- Minecraft Crash Report ----
// Ouch. That hurt :(
 
Time: 2025-05-01 18:23:46
Description: Exception in server tick loop
 
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1598)
	at knot//ca.landonjw.gooeylibs2.api.tasks.TaskManager.tick(TaskManager.java:35)
	at knot//net.minecraft.server.MinecraftServer.handler$bgl000$gooeylibs-api$gooeylibs$onTick(MinecraftServer.java:7623)
	at knot//net.minecraft.server.MinecraftServer.method_3748(MinecraftServer.java:940)
	at knot//net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:697)
	at knot//net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:281)
	at java.base/java.lang.Thread.run(Thread.java:1583)
</details>