### PR TITLE
Migrate to Minecraft 26.1.2

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     id("gooeylibs.base-conventions")
-    id("net.neoforged.moddev") version "1.0.11"
+    id("net.neoforged.moddev") version libs.versions.neo.moddev.get()
 }
 
 neoForge {
-    neoFormVersion = "1.21.1-20240808.144430"
+    neoFormVersion = "26.1.2-1"
 }
 
 repositories {

--- a/api/src/main/resources/fabric.mod.json
+++ b/api/src/main/resources/fabric.mod.json
@@ -15,8 +15,8 @@
     "gooeylibs.accessor.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.16.0",
-    "minecraft": ">=1.21",
-    "java": ">=21"
+    "fabricloader": ">=0.18.0",
+    "minecraft": ">=26.1",
+    "java": ">=25"
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = project.group
-version = "${project.property("modVersion")}-1.21.x"
+version = "${project.property("modVersion")}-26.1.x"
 
 val isSnapshot = project.property("snapshot")?.equals("true") ?: false
 if (isSnapshot) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ name=GooeyLibs
 modVersion=3.1.1
 snapshot=false
 
-minecraft=1.21.1
-forge=47.0.3
-fabric-loader=0.14.21
-fabric-api=0.83.1
+minecraft=26.1.2
+fabric-loader=0.18.4
+fabric-api=0.151.0+26.1.2

--- a/gradle/build-logic/src/main/kotlin/gooeylibs.base-conventions.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/gooeylibs.base-conventions.gradle.kts
@@ -13,8 +13,8 @@ version = rootProject.version
 
 indra {
     javaVersions {
-        minimumToolchain(21)
-        target(21)
+        minimumToolchain(25)
+        target(25)
     }
 }
 
@@ -33,7 +33,7 @@ license {
     header(rootProject.file("HEADER.txt"))
     properties {
         this.set("name", "GooeyLibs")
-        this.set("years", "201x - 2024")
+        this.set("years", "201x - 2026")
     }
 }
 

--- a/gradle/build-logic/src/main/kotlin/gooeylibs.loader-conventions.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/gooeylibs.loader-conventions.gradle.kts
@@ -17,6 +17,6 @@ modrinth {
 
     versionType.set("release")
 
-    gameVersions.set(listOf("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4"))
+    gameVersions.set(listOf("26.1", "26.1.1", "26.1.2"))
     debugMode.set(false)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [plugins]
-loom = "fabric-loom:1.8.10"
+loom = "net.fabricmc.fabric-loom:1.17"
 indra = { id = "net.kyori.indra" }
 
 [versions]
@@ -8,22 +8,22 @@ minotaur = "2.+"
 licenser = "0.6.1"
 shadow = "8.1.1"
 indra = "3.1.3"
-neo-moddev = "1.0.11"
+neo-moddev = "2.0.141"
 
 # Languages
 kotlin = "2.0.0"
 
 # Game Level
-minecraft = "1.21.1"
-fabric-loader = "0.16.4"
+minecraft = "26.1.2"
+fabric-loader = "0.18.4"
 
 # Text Serialization
-adventure = "4.18.0"
-adventure-platform = "5.14.2"
+adventure = "4.26.1"
+adventure-platform = "6.9.0"
 
 # Mixins
 mixin = "0.13.4+mixin.0.8.5"
-mixinExtras = "0.4.1"
+mixinExtras = "0.5.4"
 
 # Unit Testing
 junit = "5.10.3"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/launchers/fabric/api-repack/build.gradle.kts
+++ b/launchers/fabric/api-repack/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencies {
     minecraft(libs.minecraft)
-    mappings(loom.officialMojangMappings())
     compileOnly(libs.fabric.loader)
 }
 
@@ -22,9 +21,6 @@ tasks {
     jar {
         from(zipTree(api.tasks.jar.flatMap { it.archiveFile })) {
             exclude("META-INF/MANIFEST.MF")
-        }
-        manifest {
-            attributes("Fabric-Loom-Remap" to true)
         }
     }
 

--- a/launchers/fabric/build.gradle.kts
+++ b/launchers/fabric/build.gradle.kts
@@ -6,18 +6,17 @@ plugins {
 
 dependencies {
     minecraft(libs.minecraft)
-    mappings(loom.officialMojangMappings())
 
-    modImplementation(libs.fabric.loader)
+    implementation(libs.fabric.loader)
 
     implementation(libs.adventure.api)
     implementation(libs.adventure.minimessage)
-    modImplementation(libs.adventure.platform.fabric)
+    implementation(libs.adventure.platform.fabric)
 
     setOf(
         "fabric-lifecycle-events-v1",
         "fabric-command-api-v2"
-    ).forEach { modImplementation(fabricApi.module(it, "0.103.0+1.21.1")) }
+    ).forEach { implementation(fabricApi.module(it, "0.151.0+26.1.2")) }
 
     // API Inclusion
     api(project(":launchers:fabric:api-repack", configuration = "namedElements"))
@@ -34,7 +33,7 @@ tasks {
         }
     }
 
-    remapJar {
+    jar {
         archiveBaseName.set("GooeyLibs-Fabric")
         archiveVersion.set(project.version as String)
     }
@@ -53,5 +52,5 @@ publishing {
 
 modrinth {
     loaders.set(listOf("fabric"))
-    uploadFile.set(tasks["remapJar"])
+    uploadFile.set(tasks["jar"])
 }

--- a/launchers/fabric/src/main/resources/fabric.mod.json
+++ b/launchers/fabric/src/main/resources/fabric.mod.json
@@ -15,8 +15,8 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.16.0",
-    "minecraft": ">=1.21",
-    "java": ">=21"
+    "fabricloader": ">=0.18.0",
+    "minecraft": ">=26.1",
+    "java": ">=25"
   }
 }

--- a/launchers/neoforge/build.gradle.kts
+++ b/launchers/neoforge/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     id("gooeylibs.loader-conventions")
-    id("net.neoforged.moddev") version "1.0.11"
+    id("net.neoforged.moddev") version libs.versions.neo.moddev.get()
 }
 
 neoForge {
-    version = "21.1.59"
+    version = "26.1.2.75"
     validateAccessTransformers = true
 
     val client = runs.create("client")


### PR DESCRIPTION
## Summary
- Gradle 8.10 → 9.4, Java 21 → 25
- Loom 1.8.10 → 1.17 (no remapping: drop mappings, `modImplementation` → `implementation`, `remapJar` → `jar`, remove `Fabric-Loom-Remap` manifest attribute)
- ModDevGradle 1.0.11 → 2.0.141
- NeoForge 21.1.59 → 26.1.2.75, NeoForm → 26.1.2-1
- Fabric Loader 0.16.4 → 0.18.4, Fabric API → 0.151.0+26.1.2
- Adventure API 4.18.0 → 4.26.1, Adventure Platform 5.14.2 → 6.9.0
- MixinExtras 0.4.1 → 0.5.4
- Updated mod metadata (fabric.mod.json) to require Java 25, MC ≥26.1, Fabric Loader ≥0.18.0
- Updated Modrinth game versions to 26.1.x
- Updated license header years to 2026

## Notes
- Source code itself is unchanged — this is a build-system-only migration
- MC 26.1 ships unobfuscated, so Loom no longer needs to remap; existing mixin targets should be verified against the new unobfuscated names